### PR TITLE
Add ability to deselect a label

### DIFF
--- a/src/components/PdfRenderer/Overlay/Overlay.js
+++ b/src/components/PdfRenderer/Overlay/Overlay.js
@@ -16,7 +16,16 @@ function Overlay({ items, scale, onItemMove }) {
   const overlayRef = useRef(null)
   const [selectedItemId, setSelectedItemId] = useState(null)
   return (
-    <div ref={overlayRef} className={styles.overlay}>
+    <div
+      ref={overlayRef}
+      className={styles.overlay}
+      style={{
+        position: selectedItemId !== null ? 'absolute' : null
+      }}
+      onClick={() => {
+        setSelectedItemId(null)
+      }}
+    >
       {items.map(item => (
         <OverlayItem
           key={item.id}
@@ -33,7 +42,10 @@ function Overlay({ items, scale, onItemMove }) {
             )
           }
           isSelected={item.id === selectedItemId}
-          onClick={() => setSelectedItemId(item.id)}
+          onClick={event => {
+            setSelectedItemId(item.id)
+            event.stopPropagation()
+          }}
         />
       ))}
     </div>

--- a/src/components/PdfRenderer/PdfViewport.module.css
+++ b/src/components/PdfRenderer/PdfViewport.module.css
@@ -16,7 +16,8 @@
 }
 
 .page .overlay {
-  /* pointer-events: none; */
+  width: 100%;
+  height: 100%;
 }
 
 .page .overlay .item {


### PR DESCRIPTION
When a modification is selected the overlay intercepts a click event and
unselect that modification, it than stops the event from propagating to
the canvas - so that no new modification will be placed.